### PR TITLE
Fix 三色同順 yaku

### DIFF
--- a/yaku.js
+++ b/yaku.js
@@ -264,20 +264,15 @@ const YAKU =
         return (res[0] && res[1] && res[2]) || (res[3] && res[4] && res[5]) || (res[6] && res[7] && res[8])
     }},
     "三色同順":{"han":2, "isFuroMinus":true, "check":(o)=>{
-        let res = [0,0,0,0]
+        let res = [];
         for (let v of o.currentPattern) {
-            if (v.length <= 2 || v[0] === v[1]) {
-                res[3]++
-                continue
-            }
-            let i = MPSZ.indexOf(v[0][1])
-            if (res[i])
-                res[3] = parseInt(v[0])
-            else
-                res[i] = parseInt(v[0])
+            if (v.length <= 2 || v[0] === v[1] || v[0].includes('z')) continue;
+
+            let value = parseInt(v[0]);
+            res[value] = res[value] ?? new Set();
+            res[value].add(v[0][1]);
         }
-        res = new Set(res)
-        return res.size <= 2 && !res.has(0)
+        return res.some((value) => value.size === 3);
     }},
     "断么九":{"han":1, "check":(o)=>{
         for (let v of o.furo)


### PR DESCRIPTION
Hi, thank you for the great library!

I've found a small bug with the 三色同順 yaku (I think).

Bug:
`22678p345687m34s+5s` return true because there are two chis of both 3 and 6 (`res = [3, 6, 3, 6]`) which makes `(new Set([3, 6]).size <= 2) === true`.

Fix:
For each starting number of a chi of M/P/S I create a set to hold the suits. I then check that at least 1 has all suits in its set.